### PR TITLE
fix: fix multishipping functionality

### DIFF
--- a/Model/Order/BrandDataPreparer.php
+++ b/Model/Order/BrandDataPreparer.php
@@ -5,7 +5,7 @@ namespace Marketplacer\BrandApi\Model\Order;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\Quote;
-use Magento\Quote\Model\Quote\Item;
+use Magento\Quote\Model\Quote\Item\AbstractItem;
 use Marketplacer\BrandApi\Api\BrandRepositoryInterface;
 use Marketplacer\BrandApi\Api\BrandAttributeRetrieverInterface;
 
@@ -55,11 +55,11 @@ class BrandDataPreparer
     }
 
     /**
-     * @param Item $quoteItem
+     * @param AbstractItem $quoteItem
      * @return mixed
      * @throws LocalizedException
      */
-    public function getBrandIdByQuoteItem(Item $quoteItem)
+    public function getBrandIdByQuoteItem(AbstractItem $quoteItem)
     {
         $brandAttributeCode = $this->brandAttributeRetriever->getAttributeCode();
         return $quoteItem->getProduct()->getData($brandAttributeCode);

--- a/Test/Unit/Model/Order/BrandDataPreparerTest.php
+++ b/Test/Unit/Model/Order/BrandDataPreparerTest.php
@@ -145,11 +145,22 @@ class BrandDataPreparerTest extends TestCase
             ->with($this->brandAttributeCode)
             ->willReturn(null);
 
+        $addressItemMock = $this->createMock(\Magento\Quote\Model\Quote\Address\Item::class);
+        $addressItemMock
+            ->expects($this->once())
+            ->method('getProduct')
+            ->willReturn($productMock3 = $this->createMock(\Magento\Catalog\Model\Product::class));
+        $productMock3
+            ->expects($this->once())
+            ->method('getData')
+            ->with($this->brandAttributeCode)
+            ->willReturn(null);
+
         $quote = $this->createMock(\Magento\Quote\Model\Quote::class);
         $quote
             ->expects($this->once())
             ->method('getAllVisibleItems')
-            ->willReturn([$quoteItemMock1, $quoteItemMock2]);
+            ->willReturn([$quoteItemMock1, $quoteItemMock2, $addressItemMock]);
 
         $this->assertEquals($resulBrandIds, $this->brandDataPreparer->getBrandIdsByQuote($quote));
     }


### PR DESCRIPTION
During the Adobe QA process a bug with the multishipping functionality was discovered. 
This change resolves the issue.

**Release Checklist:**
<!-- tick the box to show you thought about it, but give more info if you made changes. -->
- [x] Authentication is on point (you are who you say you are)
- [x] Authorisation is on point (you are allowed to access this)
- [x] Data and input/output validation controls (SQL injection, XSS attacks, file validation, type conversion)
- [x] Error and exception handling controls (transaction rollbacks, parsing external errors)
- [x] Any newly introduced PII or confidential data is appropriately handled.  This includes external systems like Rollbar and Datadog, but also applies internally to Dupliplacer, Umbrella_Placer and the like.
- [x] Aware of the downstream/upstream effects this change will have. The Marketplacer ecosystem is beyond complicated and now has many system dependencies.  Take the time to understand how your change interacts with them and speak to some teams if you need to (MConnect, Cerberus, Graphql, API V2, Headless, Connected, Fullstack, Minsights, Umbrella_Placer, Spreadsheet Uploaders, MStores, MultiStores, and more!)
- [x] Supporting documentation published. A release is not just pushing a code change, it's also communicating it.
In-App documentation, Knowledgebase, API Docs, Tettra Docs, Postman Collection, Lucid Charts, and your PM knows what's up.